### PR TITLE
Feature: Download images in parallel.

### DIFF
--- a/DanbooruDownloader/Commands/DumpCommand.cs
+++ b/DanbooruDownloader/Commands/DumpCommand.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DanbooruDownloader.Commands
@@ -18,7 +19,7 @@ namespace DanbooruDownloader.Commands
     {
         static Logger Log = LogManager.GetCurrentClassLogger();
 
-        public static async Task Run(string path, long startId, bool ignoreHashCheck, bool includeDeleted)
+        public static async Task Run(string path, long startId, int parallelDownloads, bool ignoreHashCheck, bool includeDeleted)
         {
             string tempFolderPath = Path.Combine(path, "_temp");
             string imageFolderPath = Path.Combine(path, "images");
@@ -149,11 +150,12 @@ namespace DanbooruDownloader.Commands
                         Log.Info($"{shouldUpdateCount}/{posts.Length} posts are updated. {pendingCount} posts are pending. Downloading {shouldDownloadCount} posts ...");
                     }
 
-                    foreach (Post post in posts)
+                    var semaphore = new Semaphore(parallelDownloads, parallelDownloads);
+                    Parallel.ForEach(posts, async post =>
                     {
                         if (!post.IsValid)
                         {
-                            continue;
+                            return;
                         }
 
                         string metadataPath = GetPostLocalMetadataPath(imageFolderPath, post);
@@ -162,6 +164,7 @@ namespace DanbooruDownloader.Commands
 
                         PathUtility.CreateDirectoryIfNotExists(Path.GetDirectoryName(imagePath));
 
+                        semaphore.WaitOne();
                         try
                         {
                             await TaskUtility.RunWithRetry(async () =>
@@ -213,7 +216,11 @@ namespace DanbooruDownloader.Commands
                             Log.Error($"Can't retryable exception was occured : Id={post.Id}");
                             post.IsValid = false;
                         }
-                    }
+                        finally
+                        {
+                            semaphore.Release();
+                        }
+                    });
 
                     Log.Info("Updating database ...");
                     SQLiteUtility.InsertOrReplace(connection, posts.Where(p => p.IsValid).Select(p => p.JObject));

--- a/DanbooruDownloader/Program.cs
+++ b/DanbooruDownloader/Program.cs
@@ -25,6 +25,7 @@ namespace DanbooruDownloader
 
                 CommandArgument outputPathArgument = command.Argument("path", "Output path.", false);
                 CommandOption startIdOption = command.Option("-s|--start-id <id>", "Starting Id. Default is 1.", CommandOptionType.SingleValue);
+                CommandOption parallelDownloadsOption = command.Option("-p|--parallel-downloads <value>", "Number of images to download simultaneously. Default is 5.", CommandOptionType.SingleValue);
                 CommandOption ignoreHashCheckOption = command.Option("-i|--ignore-hash-check", "Ignore hash check.", CommandOptionType.NoValue);
                 CommandOption includeDeletedOption = command.Option("-d|--deleted", "Include deleted posts.", CommandOptionType.NoValue);
 
@@ -32,6 +33,7 @@ namespace DanbooruDownloader
                 {
                     string path = outputPathArgument.Value;
                     long startId = 1;
+                    int parallelDownloads = 5;
                     bool ignoreHashCheck = ignoreHashCheckOption.HasValue();
                     bool includeDeleted = includeDeletedOption.HasValue();
 
@@ -40,8 +42,13 @@ namespace DanbooruDownloader
                         Console.WriteLine("Invalid start id.");
                         return -2;
                     }
+                    if (parallelDownloadsOption.HasValue() && !int.TryParse(parallelDownloadsOption.Value(), out parallelDownloads))
+                    {
+                        Console.WriteLine("Invalid number of parallel downloads.");
+                        return -2;
+                    }
 
-                    DumpCommand.Run(path, startId, ignoreHashCheck, includeDeleted).Wait();
+                    DumpCommand.Run(path, startId, parallelDownloads, ignoreHashCheck, includeDeleted).Wait();
 
                     return 0;
                 });


### PR DESCRIPTION
Danbooru [doesn't limit reads](https://danbooru.donmai.us/forum_topics/13628) so images can be downloaded in parallel. It improves significantly the time to download the entire dataset.

Even though there is no limit, I added a throttling option just in case. You can specify the number of images to be downloaded simultaneously with the `--parallel-downloads` option.