### PR TITLE
Updated to connect to Danbooru again

### DIFF
--- a/DanbooruDownloader/Utilities/DanbooruUtility.cs
+++ b/DanbooruDownloader/Utilities/DanbooruUtility.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,7 +15,10 @@ namespace DanbooruDownloader.Utilities
         {
             string query = $"id:>={startId} order:id_asc";
             string urlEncodedQuery = WebUtility.UrlEncode(query);
-            return $"https://danbooru.donmai.us/posts.json?tags={urlEncodedQuery}&page=1&limit=1000&login={WebUtility.UrlEncode(username)}&api_key={WebUtility.UrlEncode(apikey)}";
+            string urlEncodedUsername = WebUtility.UrlEncode(username);
+            string urlEncodedApikey = WebUtility.UrlEncode(apikey);
+            string urlstring = $"tags={urlEncodedQuery}&limit=1000&page=1&api_key={urlEncodedApikey}&login={urlEncodedUsername}";
+            return $"https://danbooru.donmai.us/posts.json?{urlstring}";
         }
 
         public static async Task<JObject[]> GetPosts(long startId, string username, string apikey)
@@ -23,6 +26,7 @@ namespace DanbooruDownloader.Utilities
             using (HttpClient client = new HttpClient())
             {
                 string url = GetPostsUrl(startId, username, apikey);
+				client.DefaultRequestHeaders.Add("User-Agent", "C# App");
                 string jsonString = await client.GetStringAsync(url);
 
                 JArray jsonArray = JArray.Parse(jsonString);

--- a/DanbooruDownloader/Utilities/SQLiteUtility.cs
+++ b/DanbooruDownloader/Utilities/SQLiteUtility.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Data.Sqlite;
+using Microsoft.Data.Sqlite;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -72,7 +72,8 @@ CREATE TABLE IF NOT EXISTS posts
     tag_string_meta TEXT,
     file_url TEXT,
     large_file_url TEXT,
-    preview_file_url TEXT
+    preview_file_url TEXT,
+    media_asset TEXT
 );";
                 command.ExecuteNonQuery();
 


### PR DESCRIPTION
DumpCommand:
Changed Download to HTTP client with a user agent because Danbooru requires a user agent.
Clarified MD5 not matching error message in the exception.

DanbooruUtility:
Moved encoding of username and apikey out of url creation for clarity
Added a user agent to the request because Danbooru requires it now.

SQLiteUtility:
Added a missing field "media_asset". It is pretty useless but I am not familiar enough with dotnet to know how to remove it from the Post oblect.
Possible future enhancement remove fields from post and only keep and insert the fields you really want.